### PR TITLE
use include_dir!() for internals so cordl can run standalone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "fs_extra",
+ "include_dir",
  "indent_write",
  "itertools",
  "log",
@@ -472,6 +473,25 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "include_dir"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18762faeff7122e89e0857b02f7ce6fcc0d101d5e9ad2ad7846cc01d61b7f19e"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "indent_write"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ bytes = "*"
 byteorder = "1"
 topological-sort = "0.2"
 fs_extra = "*"
+include_dir= "*"
 
 # utils
 pathdiff = "0.2"

--- a/src/generate/config.rs
+++ b/src/generate/config.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 pub struct GenerationConfig {
     pub source_path: PathBuf,
     pub header_path: PathBuf,
-    pub src_internals_path: PathBuf,
     pub dst_internals_path: PathBuf,
     pub dst_header_internals_file: PathBuf,
 }


### PR DESCRIPTION
This way we don't depend on the folder existing in the cwd of wherever we run cordl