### PR TITLE
Dont write static properties

### DIFF
--- a/src/generate/members_serialize.rs
+++ b/src/generate/members_serialize.rs
@@ -549,6 +549,10 @@ impl Sortable for CppConstructorImpl {
 
 impl Writable for CppPropertyDecl {
     fn write(&self, writer: &mut super::writer::CppWriter) -> color_eyre::Result<()> {
+        if !self.instance {
+            return Ok(())
+        }
+        
         let mut prefix_modifiers: Vec<&str> = vec![];
         let suffix_modifiers: Vec<&str> = vec![];
 
@@ -559,10 +563,6 @@ impl Writable for CppPropertyDecl {
         }
         if let Some(setter) = &self.setter {
             property_vec.push(format!("put={setter}"));
-        }
-
-        if !self.instance {
-            prefix_modifiers.push("static");
         }
 
         let property = property_vec.join(", ");


### PR DESCRIPTION
Static properties should not be written as they do not function correctly at runtime and will cause compile errors in the future when fixed <https://github.com/llvm/llvm-project/issues/90743#issuecomment-2115775553>