### PR TITLE
Hold string in CsValue::Char

### DIFF
--- a/src/generate/cs_members.rs
+++ b/src/generate/cs_members.rs
@@ -93,7 +93,7 @@ pub struct CsMethodSizeData {
 #[derive(Clone, Debug, PartialEq, PartialOrd)]
 pub enum CsValue {
     String(String),
-    Char(char),
+    Char(String),
     Bool(bool),
 
     U8(u8),

--- a/src/generate/cs_type.rs
+++ b/src/generate/cs_type.rs
@@ -863,7 +863,7 @@ impl CsType {
                     .escape_default()
                     .to_string();
 
-                CsValue::Char(res.chars().next().unwrap())
+                CsValue::Char(res)
             }
             Il2CppTypeEnum::String => {
                 let stru16_len = cursor.read_compressed_i32::<Endian>().unwrap();


### PR DESCRIPTION
Fixes chars which use unicode escape sequences