### PR TITLE
JSON Improvements

### DIFF
--- a/src/generate/json/json_gen.rs
+++ b/src/generate/json/json_gen.rs
@@ -66,6 +66,7 @@ pub struct JsonProperty {
     pub ty_name: String,
     pub ty_tag: JsonResolvedTypeData,
     pub instance: bool,
+    pub indexable: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub getter: Option<(u32, String)>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -142,6 +143,7 @@ fn make_property(property: &CsProperty, name_resolver: &JsonNameResolver) -> Jso
         ty_tag: p_type,
         ty_name,
         instance: property.instance,
+        indexable: property.indexable,
         setter: p_setter,
         getter: p_getter,
     }

--- a/src/generate/json/json_gen.rs
+++ b/src/generate/json/json_gen.rs
@@ -53,6 +53,7 @@ pub struct JsonField {
     pub name: String,
     pub ty_name: String,
     pub ty_tag: JsonResolvedTypeData,
+    pub instance: bool,
     pub offset: Option<u32>,
 }
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -60,6 +61,7 @@ pub struct JsonProperty {
     pub name: String,
     pub ty_name: String,
     pub ty_tag: JsonResolvedTypeData,
+    pub instance: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub getter: Option<(u32, String)>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -72,6 +74,7 @@ pub struct JsonMethod {
     pub ret: String,
     pub ret_ty_tag: JsonResolvedTypeData,
     pub parameters: Vec<JsonParam>,
+    pub instance: bool,
     pub method_info: JsonMethodInfo,
 }
 
@@ -99,10 +102,10 @@ fn make_field(field: &CsField, name_resolver: &JsonNameResolver) -> JsonField {
 
     JsonField {
         name: field.name.to_string(),
-
         ty_name,
         offset,
         ty_tag: ty,
+        instance: field.instance
     }
 }
 fn make_property(property: &CsProperty, name_resolver: &JsonNameResolver) -> JsonProperty {
@@ -122,6 +125,7 @@ fn make_property(property: &CsProperty, name_resolver: &JsonNameResolver) -> Jso
         name: property.name.to_string(),
         ty_tag: p_type,
         ty_name,
+        instance: property.instance,
         setter: p_setter,
         getter: p_getter,
     }
@@ -168,6 +172,7 @@ fn make_method(method: &CsMethod, name_resolver: &JsonNameResolver) -> JsonMetho
     JsonMethod {
         name: method.name.to_string(),
         parameters: params,
+        instance: method.instance,
         ret: ret_ty_name,
         ret_ty_tag: ret_ty,
         method_info: json_method_info,

--- a/src/generate/json/json_gen.rs
+++ b/src/generate/json/json_gen.rs
@@ -54,6 +54,8 @@ pub struct JsonField {
     pub ty_name: String,
     pub ty_tag: JsonResolvedTypeData,
     pub instance: bool,
+    pub is_const: bool,
+    pub readonly: bool,
     pub offset: Option<u32>,
 }
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -105,7 +107,9 @@ fn make_field(field: &CsField, name_resolver: &JsonNameResolver) -> JsonField {
         ty_name,
         offset,
         ty_tag: ty,
-        instance: field.instance
+        instance: field.instance,
+        is_const: field.is_const,
+        readonly: field.readonly
     }
 }
 fn make_property(property: &CsProperty, name_resolver: &JsonNameResolver) -> JsonProperty {

--- a/src/generate/json/mod.rs
+++ b/src/generate/json/mod.rs
@@ -113,7 +113,8 @@ pub fn is_real_declaring_type(ty: &CsType, metadata: &CordlMetadata) -> bool {
         .contains("<PrivateImplementationDetails>");
     let condition3 = ty.parent.is_some()
         || ty.is_interface
-        || ty.cs_name_components.combine_all() == "System.Object";
+        || ty.cs_name_components.combine_all() == "System.Object"
+        || ty.is_value_type;
     let condition4 = !ty.namespace().contains("$$struct");
 
     // -1 if no declaring type, meaning root


### PR DESCRIPTION
Issues this PR addresses:
1. Value types* are not included when outputting to json. This PR fixes it by making sure that, if a type doesn't inherit from `System::Object` but is a value type, it still gets included in the outputted JSON. There might be a better fix for this, but this seems to work and doesn't generate garbage.
2. Adds an `instance` field to fields, properties, and methods, which shows whether they're instance or static fields.
3. Added the `readonly` and `is_const` fields, which shows whether they're readonly or constant.
4. Add a `template` field for methods and classes, which contains the list of template arguments in order (if present).

note: this probably shouldn't be merged yet as I'm still finding new things to add as time goes on

\* may only be some value types, not sure; but `UnityEngine::Color` and `UnityEngine::Vector3` were among those excluded, which probably should be generated