### PR TITLE
fix generic interface methods

### DIFF
--- a/src/generate/cpp/cpp_type.rs
+++ b/src/generate/cpp/cpp_type.rs
@@ -1056,7 +1056,7 @@ impl CppType {
                 };
 
                 vec![
-                format!("auto* ___internal_method_base = THROW_UNLESS((::il2cpp_utils::FindMethod(
+                format!("static auto* ___internal_method_base = THROW_UNLESS((::il2cpp_utils::FindMethod(
                     {declaring_classof_call},
                     \"{m_name}\",
                     {template_classes_array_cpp},

--- a/src/generate/cpp/cpp_type.rs
+++ b/src/generate/cpp/cpp_type.rs
@@ -976,13 +976,50 @@ impl CppType {
         let params_types_count = method_decl.parameters.len();
 
         let resolve_instance_slot_lines = if let Some(slot) = method.method_data.slot {
-            vec![format!(
-                "auto* {METHOD_INFO_VAR_NAME} = THROW_UNLESS((::il2cpp_utils::ResolveVtableSlot(
-                    {extract_self_class},
-                    {declaring_classof_call},
-                    {slot}
-                )));"
-            )]
+            match &template {
+                Some(template) => {
+                    // generic
+                    let template_names = template
+                        .just_names()
+                        .map(|t| {
+                            format!(
+                                "::il2cpp_utils::il2cpp_type_check::il2cpp_no_arg_class<{t}>::get()"
+                            )
+                        })
+                        .join(", ");
+                    let template_count = template.names.len();
+
+                    // if no template params, just empty span
+                    // avoid allocs
+                    let template_classes_array_cpp = match template_count {
+                        0 => "std::span<const Il2CppClass* const, 0>()".to_string(),
+                        _ => format!(
+                            "std::array<const Il2CppClass*, {template_count}>{{{template_names}}}"
+                        ),
+                    };
+
+                    vec![
+                    format!("static auto* ___internal_method_base = THROW_UNLESS((::il2cpp_utils::ResolveVtableSlot(
+                        {extract_self_class},
+                        {declaring_classof_call},
+                        {slot}
+                    )));"),
+                    format!("static auto* {METHOD_INFO_VAR_NAME} = THROW_UNLESS(::il2cpp_utils::MakeGenericMethod(
+                        ___internal_method_base,
+                        {template_classes_array_cpp}
+                    ));"),
+                    ]
+                }
+                None => {
+                    vec![
+                        format!("auto* {METHOD_INFO_VAR_NAME} = THROW_UNLESS((::il2cpp_utils::ResolveVtableSlot(
+                            {extract_self_class},
+                            {declaring_classof_call},
+                            {slot}
+                        )));")
+                    ]
+                }
+            }
         } else {
             vec![]
         };

--- a/src/generate/cpp/cpp_type.rs
+++ b/src/generate/cpp/cpp_type.rs
@@ -999,12 +999,12 @@ impl CppType {
                     };
 
                     vec![
-                    format!("static auto* ___internal_method_base = THROW_UNLESS((::il2cpp_utils::ResolveVtableSlot(
+                    format!("auto* ___internal_method_base = THROW_UNLESS((::il2cpp_utils::ResolveVtableSlot(
                         {extract_self_class},
                         {declaring_classof_call},
                         {slot}
                     )));"),
-                    format!("static auto* {METHOD_INFO_VAR_NAME} = THROW_UNLESS(::il2cpp_utils::MakeGenericMethod(
+                    format!("auto* {METHOD_INFO_VAR_NAME} = THROW_UNLESS(::il2cpp_utils::MakeGenericMethod(
                         ___internal_method_base,
                         {template_classes_array_cpp}
                     ));"),
@@ -1056,7 +1056,7 @@ impl CppType {
                 };
 
                 vec![
-                format!("static auto* ___internal_method_base = THROW_UNLESS((::il2cpp_utils::FindMethod(
+                format!("auto* ___internal_method_base = THROW_UNLESS((::il2cpp_utils::FindMethod(
                     {declaring_classof_call},
                     \"{m_name}\",
                     {template_classes_array_cpp},


### PR DESCRIPTION
Generic methods on interface types such as `IReadonlyBeatmapData::GetBeatmapDataItems<T>` only resolved the vtable slot and did not create a generic method info with the template arguments which caused the method invoke to fail